### PR TITLE
Add shortcut to TarSafe constructor

### DIFF
--- a/tarsafe/tarsafe.py
+++ b/tarsafe/tarsafe.py
@@ -69,3 +69,5 @@ class TarSafe(tarfile.TarFile):
 
 class TarSafeException(Exception):
     pass
+
+open = TarSafe.open


### PR DESCRIPTION
The default tarfile library has a [documented shortcut](https://docs.python.org/3/library/tarfile.html#tarfile.open) which is nothing more than a [single exported reference](https://github.com/python/cpython/blob/c7b0feca25fc68ec3e0884b82e5f45a4da011e8e/Lib/tarfile.py#L2491) to the `TarFile.open()` class method. This adds similar support to TarSafe.