### PR TITLE
expose all tarfile members in tarsafe module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,5 @@ python = ">=3.6"
 pytest = "^6.1.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "setuptools"]
 build-backend = "poetry.masonry.api"

--- a/tarsafe/__init__.py
+++ b/tarsafe/__init__.py
@@ -3,3 +3,6 @@ __author__ = "Andrew Scott"
 __license__ = "MIT"
 
 from .tarsafe import *
+from .tarsafe import __all__
+
+__all__ = __all__ + ["__version__", "__author__", "__license__"]

--- a/tarsafe/tarsafe.py
+++ b/tarsafe/tarsafe.py
@@ -1,11 +1,27 @@
+"""
+tarsafe module is a more secure drop-in replacement for tarfile module.
+
+We expose everything tarfile does, but some methods are overridden to add
+safety features.
+"""
+
 import os
 import pathlib
 import tarfile
+from tarfile import *  # noqa: F401, F403
+
+
+__all__ = tarfile.__all__ + [
+    "TarSafe",
+    "TarSafeException",
+]
+
 
 class TarSafe(tarfile.TarFile):
     """
     A safe subclass of the TarFile class for interacting with tar files.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.directory = os.getcwd()
@@ -63,11 +79,17 @@ class TarSafe(tarfile.TarFile):
             if not os.path.abspath(os.path.join(self.directory, link_file)).startswith(self.directory):
                 return True
         return False
-    
+
     def _is_device(self, tarinfo):
         return tarinfo.ischr() or tarinfo.isblk()
 
+
 class TarSafeException(Exception):
     pass
+
+
+class TarFile(TarSafe):
+    """Override of tarfile.TarFile to maintain compatibility."""
+
 
 open = TarSafe.open

--- a/test/test_tarsafe.py
+++ b/test/test_tarsafe.py
@@ -1,8 +1,12 @@
 import os
-import sys
+import inspect
+import tarfile
+
 import pytest
 
+import tarsafe
 from tarsafe import TarSafe, TarSafeException
+
 
 def test_bad_files():
     files = os.listdir("./test/data/bad")
@@ -10,6 +14,7 @@ def test_bad_files():
         with pytest.raises(TarSafeException) as ex:
             with TarSafe.open(f"./test/data/bad/{file_}", "r") as tar:
                 tar.extractall()
+
 
 def test_good_files():
     files = os.listdir("./test/data/good")
@@ -19,6 +24,7 @@ def test_good_files():
         assert os.path.exists("./evil.sh")
         os.remove("./evil.sh")
 
+
 def test_good_file():
     files = os.listdir("./test/data/good")
     for file_ in files:
@@ -26,3 +32,11 @@ def test_good_file():
             tar.extract("evil.sh")
         assert os.path.exists("./evil.sh")
         os.remove("./evil.sh")
+
+
+def test_tarsafe_is_dropin_for_tarfile():
+    assert _get_exposed_members(tarfile) <= _get_exposed_members(tarsafe)
+
+
+def _get_exposed_members(module):
+    return set(module.__all__)


### PR DESCRIPTION
> Tarsafe is a drop-in replacement for the tarfile module 

so what I did was 
`s/import tarfile/import tarsafe as tarfile/`

but that of course failed me when during runtime in production it hit the line `tarfile.TarInfo`